### PR TITLE
ci(publish): make npm publish idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,16 @@ jobs:
 
       - name: Publish to npm
         if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run)"
-        run: npm publish --provenance --access public
+        run: |
+          PKG_NAME="$(node -p "require('./package.json').name")"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          # Idempotent: a version can only be published to npm once. If it is
+          # already there (e.g. a Release was created for a version published
+          # manually via workflow_dispatch), skip rather than fail the run.
+          if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+            echo "::notice::$PKG_NAME@$PKG_VERSION is already published — skipping publish."
+            exit 0
+          fi
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What
Makes the **Publish to npm** step in `publish.yml` idempotent: it skips publishing (and reports success) when the package version already exists on npm, instead of failing on npm's duplicate-version error.

```yaml
if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
  echo "::notice::... already published — skipping publish."
  exit 0
fi
npm publish --provenance --access public
```

## Why
`2.0.0` was already published to npm via a manual `workflow_dispatch` run. The workflow also triggers on `release: published`, so creating the GitHub Release `v2.0.0` would re-run publish and **fail** on the "version already exists" error — a harmless but red run. This guard keeps that re-run green.

This also makes future releases safe to re-run if a publish partially happened.

## Notes
- Behaviour for a brand-new version is unchanged — it publishes normally with provenance.
- No production/runtime code touched; CI-only change.

https://claude.ai/code/session_01Sq8tdmk5Wrrmw7hhNHLPse

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sq8tdmk5Wrrmw7hhNHLPse)_