### PR TITLE
docs(readme): add npm version, downloads and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # react-native-ssl-manager
 
+[![npm version](https://img.shields.io/npm/v/react-native-ssl-manager.svg)](https://www.npmjs.com/package/react-native-ssl-manager)
+[![npm downloads](https://img.shields.io/npm/dm/react-native-ssl-manager.svg)](https://www.npmjs.com/package/react-native-ssl-manager)
+[![license](https://img.shields.io/npm/l/react-native-ssl-manager.svg)](./LICENSE)
+
 Production-ready SSL certificate pinning for React Native and Expo. Protects against MITM attacks with platform-native enforcement on both iOS and Android.
 
 ## Features


### PR DESCRIPTION
## Summary

Adds dynamic [shields.io](https://shields.io) badges to the top of the README:

- **npm version** — always shows the latest published version (currently `2.0.1`)
- **npm downloads** — monthly download count
- **license**

These are live badges, so they update automatically on every future release — no manual version bump in the README needed.

## Notes

- Docs-only change; no source or behavior changes.
- Follow-up to the v2.0.1 release (fix for #9), which is already published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBmWckZ7dSNzYKdYMxkA53

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBmWckZ7dSNzYKdYMxkA53)_