### PR TITLE
feat(ios): add build/launch-time off-switch for TrustKit (e2e/Detox)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-07-03
+
+### Added
+- **iOS: build/launch-time off-switch for TrustKit**, so e2e tests (Detox) that
+  hit a mocked backend are not blocked by pin validation. TrustKit is installed
+  at launch via an Objective-C `+load` hook and swizzles `NSURLSession`
+  process-wide before any JS runs, so `setUseSSLPinning(false)` is too late for a
+  test run. Pinning is now skipped entirely (no swizzling) when any of these is
+  set — with no effect on production builds:
+  - `Info.plist` boolean `RNSSLManagerDisabled = YES` (build-time exclude)
+  - launch argument `--disable-ssl-pinning` (e.g. Detox launchArgs)
+  - `NSUserDefaults` key `RNSSLManagerDisabled` (e.g. Detox `launchArgs: { RNSSLManagerDisabled: true }`)
+  - environment variable `RN_SSL_MANAGER_DISABLED=1` (Xcode scheme / CI)
+
+  ([#9](https://github.com/huytdps13400/react-native-ssl-manager/issues/9))
+
 ## [2.0.1] - 2026-07-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -296,6 +296,41 @@ Default state is **enabled** (`true`). State is persisted in:
 - iOS: `UserDefaults`
 - Android: `SharedPreferences` (context: `AppSettings`, key: `useSSLPinning`)
 
+## Disabling for e2e tests (Detox, mocked backends)
+
+On iOS, TrustKit is installed at app launch via an Objective-C `+load` hook —
+**before any JavaScript runs** — and swizzles `NSURLSession` process-wide.
+Because it cannot be deinitialized within a running process, calling
+`setUseSSLPinning(false)` from JS is **too late** for an e2e run: the swizzle is
+already in place, so a mocked backend whose certificate doesn't match your pins
+gets its connection blocked (requests appear to hang / never respond).
+
+Use one of these **before-launch** off-switches to skip TrustKit entirely for a
+test build or a single test launch. Each also prevents the swizzling, so mocked
+traffic flows normally. They have **no effect on your production build** unless
+you set them there.
+
+**Detox — per-launch (no separate build):**
+
+```js
+await device.launchApp({
+  newInstance: true,
+  launchArgs: { RNSSLManagerDisabled: true },
+});
+```
+
+**Build-time exclude (a dedicated test/e2e configuration):** set a boolean
+`RNSSLManagerDisabled = YES` in that configuration's `Info.plist`.
+
+**Other channels** (all equivalent):
+- Launch argument `--disable-ssl-pinning` (e.g. `xcodebuild` test args)
+- Environment variable `RN_SSL_MANAGER_DISABLED=1` (Xcode scheme / CI)
+
+> Android does not have this problem: pinning applies per-request, so
+> `setUseSSLPinning(false)` takes effect immediately without relaunching. For
+> connecting to a local mock/dev server over cleartext, the generated Network
+> Security Config already permits `localhost`, `10.0.2.2` and `10.0.3.2`.
+
 ## API Reference
 
 ### `setUseSSLPinning(usePinning: boolean): Promise<void>`

--- a/ios/SharedLogic.swift
+++ b/ios/SharedLogic.swift
@@ -46,11 +46,62 @@ class SharedLogic: NSObject {
     // initialization (bootstrap + JS call) which would otherwise crash.
     private static var trustKitInitialized = false
 
+    // Explicit off-switch for TrustKit that takes effect BEFORE the +load
+    // bootstrap installs its NSURLSession swizzling. Because TrustKit cannot be
+    // deinitialized within a running process, `setUseSSLPinning(false)` from JS
+    // is too late for e2e runners (Detox, mocked backends): the swizzle is
+    // already in place and the mock server's certificate fails pin validation.
+    // These channels let a build or a test launch opt out entirely:
+    //
+    //   • Info.plist  `RNSSLManagerDisabled = YES`  — build-time exclude, baked
+    //     into a dedicated test/e2e build configuration.
+    //   • Launch arg  `--disable-ssl-pinning`       — e.g. Detox launchArgs.
+    //   • NSUserDefaults key `RNSSLManagerDisabled`  — e.g. Detox
+    //     `launchArgs: { RNSSLManagerDisabled: true }` (argument domain).
+    //   • Env var     `RN_SSL_MANAGER_DISABLED=1`    — Xcode scheme / CI.
+    private static let disabledInfoPlistKey = "RNSSLManagerDisabled"
+    private static let disabledLaunchArg = "--disable-ssl-pinning"
+    private static let disabledEnvVar = "RN_SSL_MANAGER_DISABLED"
+
+    /**
+     * Whether pinning is force-disabled for this build/launch, independent of the
+     * runtime `useSSLPinning` flag. Checked before any TrustKit initialization so
+     * the network-delegate swizzling is never installed when disabled.
+     */
+    @objc static func isPinningDisabledByEnvironment() -> Bool {
+        let processInfo = ProcessInfo.processInfo
+
+        // Launch argument (Detox launchArgs, `xcodebuild` test args, etc.).
+        if processInfo.arguments.contains(disabledLaunchArg) {
+            return true
+        }
+
+        // Environment variable (Xcode scheme, CI).
+        if let raw = processInfo.environment[disabledEnvVar]?.lowercased(),
+           raw == "1" || raw == "true" || raw == "yes" {
+            return true
+        }
+
+        // Info.plist flag — a build-time exclude for a specific configuration.
+        if let flag = Bundle.main.object(forInfoDictionaryKey: disabledInfoPlistKey) as? Bool, flag {
+            return true
+        }
+
+        // NSUserDefaults (argument domain) — Detox `launchArgs: { RNSSLManagerDisabled: true }`.
+        if userDefaults.object(forKey: disabledInfoPlistKey) != nil,
+           userDefaults.bool(forKey: disabledInfoPlistKey) {
+            return true
+        }
+
+        return false
+    }
+
     /**
      * Bootstrap entry point invoked at app launch (via Objective-C +load).
      * Non-throwing: any failure is swallowed so launch is never blocked.
      */
     @objc static func bootstrapIfEnabled() {
+        guard !isPinningDisabledByEnvironment() else { return }
         guard getUseSSLPinning() else { return }
         do {
             let _ = try initializeSslPinning()
@@ -243,6 +294,16 @@ class SharedLogic: NSObject {
      * Initialize SSL pinning with TrustKit
      */
     static func initializeSslPinning(_ configJsonString: String) throws -> [String: Any] {
+        // Force-disabled for this build/launch (e2e, mocked backends): never
+        // install TrustKit, even if something calls setUseSSLPinning(true).
+        guard !isPinningDisabledByEnvironment() else {
+            return [
+                "message": "SSL Pinning disabled for this build/launch",
+                "domains": [],
+                "isSSLPinningEnabled": false
+            ]
+        }
+
         // Check if SSL pinning is enabled
         let isSSLPinningEnabled = getUseSSLPinning()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ssl-manager",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React Native SSL Pinning provides seamless SSL certificate pinning integration for enhanced network security in React Native apps. This module enables developers to easily implement and manage certificate pinning, protecting applications against man-in-the-middle (MITM) attacks. With dynamic configuration options and the ability to toggle SSL pinning, it's particularly useful for development and testing scenarios.",
   "main": "./src/index.ts",
   "module": "./src/index.ts",


### PR DESCRIPTION
## Summary

Follow-up to #9. After v2.0.1 fixed the Android Metro connectivity issue, @Cancercookie reported that on **iOS, TrustKit pinning blocks a mocked backend during Detox e2e tests** and asked for a way to exclude TrustKit at build time.

**Root cause:** TrustKit is installed at app launch via an Objective-C `+load` hook (`SslManagerBootstrap.mm`) — **before any JS runs** — and swizzles `NSURLSession` process-wide. Since TrustKit cannot be deinitialized within a running process, `setUseSSLPinning(false)` from JS is too late: the swizzle is already in place, so the mock server's certificate fails pin validation and requests hang.

## Changes

- Add `SharedLogic.isPinningDisabledByEnvironment()`, checked **before any TrustKit initialization** in both `bootstrapIfEnabled()` and `initializeSslPinning(_:)`. When disabled, TrustKit is never initialized and the swizzling is never installed — so mocked traffic flows normally. No effect on production builds unless the flag is set there.
- Off-switch channels (any one):
  - `Info.plist` boolean `RNSSLManagerDisabled = YES` — **build-time exclude** for a dedicated test/e2e configuration
  - launch argument `--disable-ssl-pinning` — e.g. Detox `launchArgs`
  - `NSUserDefaults` key `RNSSLManagerDisabled` — e.g. Detox `launchArgs: { RNSSLManagerDisabled: true }`
  - environment variable `RN_SSL_MANAGER_DISABLED=1` — Xcode scheme / CI
- README: new **"Disabling for e2e tests (Detox, mocked backends)"** section.
- Bump version to **2.0.2** + CHANGELOG entry.

## Notes

- No spec/JS API change — the switch is native/build-time only, so `nitrogen/` is unchanged.
- The Swift change couldn't be built locally (no iOS toolchain here); the `build-ios` CI job validates compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBmWckZ7dSNzYKdYMxkA53

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBmWckZ7dSNzYKdYMxkA53)_