### PR TITLE
feat(ios): diagnostics + string-flag support for TrustKit off-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2026-07-03
+
+### Added
+- **iOS: launch-time diagnostics for SSL pinning.** The native layer now logs to
+  the device console (prefix `[RNSSLManager]`) so it is visible whether pinning
+  was **skipped** — and via which flag — or **initialized for domains X**, and
+  which host a **blocked** connection failed on. Makes debugging e2e/mock issues
+  (#9) straightforward via Console.app or `xcrun simctl spawn booted log stream`.
+
+### Fixed
+- **iOS: the `RNSSLManagerDisabled` off-switch now also accepts string values**
+  (`YES` / `true` / `1`), not only a real boolean. A flag set via a build setting
+  or `xcconfig` (which reaches `Info.plist` as a string) was previously ignored.
+  Affects the Info.plist, `NSUserDefaults`, env var and launch-arg channels.
+
 ## [2.0.2] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -326,6 +326,16 @@ await device.launchApp({
 - Launch argument `--disable-ssl-pinning` (e.g. `xcodebuild` test args)
 - Environment variable `RN_SSL_MANAGER_DISABLED=1` (Xcode scheme / CI)
 
+The Info.plist / `NSUserDefaults` flag accepts a real boolean (`<true/>`) or a
+truthy string (`YES` / `true` / `1`).
+
+**Verify it took effect (iOS):** the native layer logs to the device console at
+launch (filter for `RNSSLManager`, e.g. in Console.app or
+`xcrun simctl spawn booted log stream --predicate 'eventMessage CONTAINS "RNSSLManager"'`):
+- `SSL pinning DISABLED for this launch via <channel>` — pinning was skipped
+- `SSL pinning ACTIVE — TrustKit installed … for domains: …` — pinning is on
+- `BLOCKED connection to <host> …` — a request failed pin validation
+
 > Android does not have this problem: pinning applies per-request, so
 > `setUseSSLPinning(false)` takes effect immediately without relaunching. For
 > connecting to a local mock/dev server over cleartext, the generated Network

--- a/ios/SharedLogic.swift
+++ b/ios/SharedLogic.swift
@@ -64,35 +64,68 @@ class SharedLogic: NSObject {
     private static let disabledEnvVar = "RN_SSL_MANAGER_DISABLED"
 
     /**
-     * Whether pinning is force-disabled for this build/launch, independent of the
-     * runtime `useSSLPinning` flag. Checked before any TrustKit initialization so
-     * the network-delegate swizzling is never installed when disabled.
+     * Interpret a flag value as a boolean. Accepts a real `Bool`/`NSNumber`
+     * (Info.plist `<true/>`, plist number) and truthy strings (`"YES"`, `"true"`,
+     * `"1"`) so the flag works whether it is set as a boolean, a build-setting
+     * string, an environment variable, or a Detox launch argument.
      */
-    @objc static func isPinningDisabledByEnvironment() -> Bool {
+    private static func isTruthy(_ value: Any?) -> Bool {
+        guard let value = value else { return false }
+        if let s = value as? String {
+            let v = s.trimmingCharacters(in: .whitespaces).lowercased()
+            return v == "1" || v == "true" || v == "yes"
+        }
+        if let n = value as? NSNumber {
+            return n.boolValue
+        }
+        if let b = value as? Bool {
+            return b
+        }
+        return false
+    }
+
+    /**
+     * Reason pinning is force-disabled for this build/launch, or `nil` if it is
+     * not. Independent of the runtime `useSSLPinning` flag and checked before any
+     * TrustKit initialization, so the network-delegate swizzling is never
+     * installed when disabled.
+     */
+    static func pinningDisableReason() -> String? {
         let processInfo = ProcessInfo.processInfo
 
-        // Launch argument (Detox launchArgs, `xcodebuild` test args, etc.).
+        // Launch argument flag (e.g. `xcodebuild` test args, `--disable-ssl-pinning`).
         if processInfo.arguments.contains(disabledLaunchArg) {
-            return true
+            return "launch arg \(disabledLaunchArg)"
         }
 
         // Environment variable (Xcode scheme, CI).
-        if let raw = processInfo.environment[disabledEnvVar]?.lowercased(),
-           raw == "1" || raw == "true" || raw == "yes" {
-            return true
+        if let raw = processInfo.environment[disabledEnvVar], isTruthy(raw) {
+            return "env \(disabledEnvVar)=\(raw)"
         }
 
         // Info.plist flag — a build-time exclude for a specific configuration.
-        if let flag = Bundle.main.object(forInfoDictionaryKey: disabledInfoPlistKey) as? Bool, flag {
-            return true
+        if isTruthy(Bundle.main.object(forInfoDictionaryKey: disabledInfoPlistKey)) {
+            return "Info.plist \(disabledInfoPlistKey)"
         }
 
         // NSUserDefaults (argument domain) — Detox `launchArgs: { RNSSLManagerDisabled: true }`.
-        if userDefaults.object(forKey: disabledInfoPlistKey) != nil,
-           userDefaults.bool(forKey: disabledInfoPlistKey) {
-            return true
+        if isTruthy(userDefaults.object(forKey: disabledInfoPlistKey)) {
+            return "NSUserDefaults \(disabledInfoPlistKey)"
         }
 
+        return nil
+    }
+
+    /**
+     * Whether pinning is force-disabled for this build/launch. Logs the channel
+     * that disabled it so the decision is visible in the device console (search
+     * `RNSSLManager` in Console.app or `xcrun simctl spawn booted log stream`).
+     */
+    @objc static func isPinningDisabledByEnvironment() -> Bool {
+        if let reason = pinningDisableReason() {
+            NSLog("[RNSSLManager] SSL pinning DISABLED for this launch via %@", reason)
+            return true
+        }
         return false
     }
 
@@ -352,15 +385,20 @@ class SharedLogic: NSObject {
         SharedLogic.sharedTrustKit = TrustKit.sharedInstance()
         trustKitInitialized = true
 
+        NSLog("[RNSSLManager] SSL pinning ACTIVE — TrustKit installed (NSURLSession swizzled) for domains: %@",
+              Array(pinnedDomains.keys).joined(separator: ", "))
+
         guard let trustKit = SharedLogic.sharedTrustKit else {
             throw SSLPinningError.invalidConfiguration
         }
 
-        // Set up validation callback (currently a no-op observer hook)
-        trustKit.pinningValidatorCallback = { result, _, _ in
+        // Observe validation decisions. Logging a blocked connection makes the
+        // "mocked backend doesn't respond" case obvious: it names the host whose
+        // certificate failed pin validation.
+        trustKit.pinningValidatorCallback = { result, hostname, _ in
             switch result.finalTrustDecision {
             case .shouldBlockConnection:
-                break
+                NSLog("[RNSSLManager] BLOCKED connection to %@ — certificate did not match the configured pins", hostname)
             case .shouldAllowConnection:
                 break
             default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ssl-manager",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "React Native SSL Pinning provides seamless SSL certificate pinning integration for enhanced network security in React Native apps. This module enables developers to easily implement and manage certificate pinning, protecting applications against man-in-the-middle (MITM) attacks. With dynamic configuration options and the ability to toggle SSL pinning, it's particularly useful for development and testing scenarios.",
   "main": "./src/index.ts",
   "module": "./src/index.ts",


### PR DESCRIPTION
## Summary

Debugging follow-up for #9. @Cancercookie reported the v2.0.2 iOS e2e off-switch still didn't disable pinning for their Detox setup. Two gaps made that hard to diagnose and could explain it:

1. **No observability** — the disable path was silent, so there was no way to tell whether the flag was read, whether pinning was skipped, or whether a connection was blocked.
2. **String flag values were ignored** — the Info.plist check used `as? Bool`, so a flag set via a build setting / `xcconfig` (which reaches `Info.plist` as a string) was silently missed.

## Changes

- **Launch-time diagnostics** (native `NSLog`, prefix `[RNSSLManager]`), visible in Console.app / `xcrun simctl spawn booted log stream`:
  - `SSL pinning DISABLED for this launch via <channel>` — skipped, and which flag did it
  - `SSL pinning ACTIVE — TrustKit installed … for domains: …` — pinning is on
  - `BLOCKED connection to <host> …` — a request failed pin validation (the smoking gun for "mock doesn't respond")
- **Robust flag parsing** via `isTruthy(_:)`: accepts a real boolean (`<true/>`), an `NSNumber`, or truthy strings (`YES` / `true` / `1`). Applies to the Info.plist, `NSUserDefaults`, env-var and launch-arg channels.
- README: documents the log lines and string-flag support.
- Bump to **2.0.3** + CHANGELOG.

## Notes

- No spec/JS API change — `nitrogen/` unchanged.
- Swift compilation is validated by the `build-ios` CI job (no iOS toolchain locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBmWckZ7dSNzYKdYMxkA53

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBmWckZ7dSNzYKdYMxkA53)_