### PR TITLE
fix: format SslManager.nitro.ts with repo prettier (3.6.2)

### DIFF
--- a/src/specs/SslManager.nitro.ts
+++ b/src/specs/SslManager.nitro.ts
@@ -37,10 +37,11 @@ export interface PinningFailureEvent {
  * Security Config via an `androidx.startup` initializer), independent of this
  * object. These methods read state and update the configuration at runtime.
  */
-export interface SslManager extends HybridObject<{
-  ios: 'swift';
-  android: 'kotlin';
-}> {
+export interface SslManager
+  extends HybridObject<{
+    ios: 'swift';
+    android: 'kotlin';
+  }> {
   /**
    * Enables or disables SSL pinning.
    *


### PR DESCRIPTION
Fixes the `lint` job failure on main after #15.

Cause: local eslint --fix used a hoisted prettier 2.8.8, which formats the `interface SslManager extends HybridObject<...>` header differently from the yarn.lock-pinned prettier 3.6.2 that CI runs.

- Reformatted with `prettier@3.6.2` (exact CI version); `prettier --check` now passes across src/, scripts/, app.plugin.js
- Nitrogen re-run: zero diff (formatting-only change)
- 104/104 tests pass, `tsc --noEmit` clean