### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-19
+
 ### Fixed
 - **Expo plugin iOS prebuild crash** — `withXcodeProject` no longer calls the
   `xcode` package's `addResourceFile`, which throws

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ssl-manager",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "React Native SSL Pinning provides seamless SSL certificate pinning integration for enhanced network security in React Native apps. This module enables developers to easily implement and manage certificate pinning, protecting applications against man-in-the-middle (MITM) attacks. With dynamic configuration options and the ability to toggle SSL pinning, it's particularly useful for development and testing scenarios.",
   "main": "./src/index.ts",
   "module": "./src/index.ts",


### PR DESCRIPTION
## Summary

Release **2.1.0** — the first release since `2.0.3`. Bumps `package.json` and finalizes the `[Unreleased]` changelog entry under `[2.1.0] - 2026-07-19`.

Merging this, then publishing a GitHub Release tagged `v2.1.0`, triggers the `publish.yml` workflow (tests → nitrogen check → `npm publish` with provenance, using the `NPM_TOKEN` secret).

## What ships in 2.1.0

- **Pinning hardening suite:** audit (report-only) mode, pin-failure reporting (`addPinningFailureListener` + `reportUris`), per-domain `expirationDate`, signed Ed25519 **OTA pin updates** (`updatePinsFromUrl`), and the `pins`/`verify`/`keygen`/`sign` **CLI**.
- **Monorepo / pnpm support:** safe postinstall for hoisted and pnpm-isolated `node_modules`, `monorepo-setup` CLI helper, Gradle config search for `apps/*` layouts.
- **Expo iOS prebuild crash fix:** the config plugin no longer throws `Cannot read properties of null (reading 'path')` on projects without a `Resources` PBXGroup.
- Docs restructured for newcomers.

Full detail in [`CHANGELOG.md`](./CHANGELOG.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdDmMzSuVbNXeQcUQNYzk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdDmMzSuVbNXeQcUQNYzk9)_