### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-21
+
 ### Added
 - `applySignedPinBundle(bundle, { publicKey })` — the verify-and-apply half of
   `updatePinsFromUrl`, for callers who fetch the signed bundle themselves

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ssl-manager",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React Native SSL Pinning provides seamless SSL certificate pinning integration for enhanced network security in React Native apps. This module enables developers to easily implement and manage certificate pinning, protecting applications against man-in-the-middle (MITM) attacks. With dynamic configuration options and the ability to toggle SSL pinning, it's particularly useful for development and testing scenarios.",
   "main": "./src/index.ts",
   "module": "./src/index.ts",


### PR DESCRIPTION
Release **2.2.0**. Bumps `package.json` and finalizes the `[Unreleased]` changelog under `[2.2.0] - 2026-07-21`.

Merging this, then dispatching `publish.yml`, publishes to npm (tests → nitrogen check → `npm publish` with provenance via the `NPM_TOKEN` secret).

## What ships in 2.2.0
- **Slimmer package** — runtime-only scripts via an explicit `files` allowlist; dev tooling moved to `scripts/dev/` and no longer published; `monorepo-setup` command + helpers + fixture removed (monorepo/pnpm support unchanged). `pack-contents` test guards against re-bloat.
- **Clearer OTA** — new `applySignedPinBundle(bundle, { publicKey })`, rewritten OTA docs (bundle format, `OtaError` codes, lower-level `verifyOtaBundle`+`setSSLConfig` path), and a callout separating `isExpired`/`expirationDate` from OTA bundle freshness.

Full detail in [`CHANGELOG.md`](./CHANGELOG.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdDmMzSuVbNXeQcUQNYzk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdDmMzSuVbNXeQcUQNYzk9)_