### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-07-21
+
 ### Added
 - `applySignedPinBundle(bundle, { publicKey })` — the verify-and-apply half of
   `updatePinsFromUrl`, for callers who fetch the signed bundle themselves

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-ssl-manager",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React Native SSL Pinning provides seamless SSL certificate pinning integration for enhanced network security in React Native apps. This module enables developers to easily implement and manage certificate pinning, protecting applications against man-in-the-middle (MITM) attacks. With dynamic configuration options and the ability to toggle SSL pinning, it's particularly useful for development and testing scenarios.",
   "main": "./src/index.ts",
   "module": "./src/index.ts",


### PR DESCRIPTION
Ships the slimmer published package (runtime-only scripts, monorepo-setup command removed) and the clearer OTA surface (applySignedPinBundle + rewritten OTA docs). See CHANGELOG for detail.


Claude-Session: https://claude.ai/code/session_01LdDmMzSuVbNXeQcUQNYzk9